### PR TITLE
Add "edit this page" links to prose.io.

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,5 +6,16 @@ permalink: 404.html
 
 <div class="page">
   <h1 class="page-title">404: Page not found</h1>
-  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}">Head back home</a> to try finding it again.</p>
+  <p class="lead">We've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}">Head back home</a> to try finding it again.</p>
+  <p class="create">Alternatively, maybe you want to <a id="create-link" href="http://prose.io/#{{ site.github.name }}/{{ site.github.project }}/tree/{{ site.github.branch }}/">create this page</a>?
 </div>
+
+<script src="/js/edit.js"></script>
+<script>
+ var path = window.location.pathname
+ var name = '{{site.github.name}}'
+ var project = '{{site.github.project}}'
+ var branch = '{{site.github.branch}}'
+ var editA = document.getElementById('create-link');
+ editA.href = createUrl(window.location.pathname, name, project, branch)
+</script>

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,13 @@ url: "http://pdxruby.org" # the base hostname & protocol for your site
 twitter_username: pdxruby
 github:
   repo: https://github.com/pdxruby/pdxruby.github.io
+  name: pdxruby
+  project: pdxruby.github.io
+  branch: master
+# For the prose editor
+prose:
+  siteurl: 'http://pdxruby.github.io'
+  relativeLinks: 'http://pdxruby.github.io/links.jsonp'
 
 # Build settings
 markdown: kramdown
@@ -22,3 +29,4 @@ timezone: "America/Los_Angeles"
 
 gems:
   - jekyll-gist
+  - jekyll-redirect-from

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,13 @@
 
     <div class="content container">
       {{ content }}
+
+      {% if page.path and site.github.name and site.github.project and site.github.branch %}
+        <div class="post-edit">
+          <a href="http://prose.io/#{{ site.github.name }}/{{ site.github.project }}/edit/{{ site.github.branch }}/{{ page.path }}">edit this page</a>
+        </div>
+      {% endif %}
+
     </div>
 
   </body>

--- a/js/edit.js
+++ b/js/edit.js
@@ -1,0 +1,35 @@
+// https://github.com/davidchambers/doctest
+
+/* sourcePath :: string -> string
+ Given a site path, suggest a source repo path
+ > sourcePath('/2099/12/31/foo')
+ '_posts/2099-12-31-foo.md'
+ > sourcePath('/foo/')
+ 'foo/index.md'
+ > sourcePath('/foo.html')
+ 'foo.md'
+ > sourcePath('/foo/bar')
+ 'foo/bar.md'
+ > sourcePath('/foo.bar')
+ 'foo.bar' y*/
+function sourcePath(path) {
+  path = path.substring(1)
+  var m
+  if (m = path.match(/^([\d]{4})\/([\d]{2})\/([\d]{2})\/([^\.\/]+)$/)) {
+    return '_posts/'+m[1]+'-'+m[2]+'-'+m[3]+'-'+m[4]+'.md'
+  }
+  if (m = path.match(/^(.*)\/$/)) {
+    return m[1] + '/index.md'
+  }
+  if (m = path.match(/^(.*)\.html$/)) {
+    return m[1] + '.md'
+  }
+  if (m = path.match(/^(.*\/)?[^\.\/]+$/)) {
+    return path + '.md'
+  }
+  return path
+}
+
+function createUrl(path, name, project, branch) {
+  return 'http://prose.io/#'+name+'/'+project+'/new/'+branch+'/'+sourcePath(path)
+}

--- a/links.jsonp
+++ b/links.jsonp
@@ -1,0 +1,11 @@
+---
+---
+callback(
+[{% for post in site.posts reversed | sort: title %} { "text": "{{post.title | replace:'"','\"'}}"
+  , "href": "{{post.url}}"
+  }
+,{% endfor %}{% for page in site.pages | sort: title %} { "text": "{{page.title | replace:'"','\"'}}"
+  , "href": "{{page.url}}"
+  }{% unless forloop.last %}
+,{% endunless%}{% endfor %}
+])


### PR DESCRIPTION
Add an "edit this page" link to every page.

Additionally, add a "create this page" link to the 404 page.

This makes the site function like a wiki.

If the user doesn't have write access, prose will create a pull request.

Fixes #5.