### PR TITLE
Configure extensionless permalinks and add a redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ description: > # this means to ignore newlines until "baseurl:"
   Also known as pdxruby and pdx.rb, is a user group for Ruby programmers in the Portland, Oregon area.
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "http://pdxruby.org" # the base hostname & protocol for your site
+# drop the extension when generating permalinks, for redirect_from and indexes
+permalink: "/:categories/:year/:month/:day"
 twitter_username: pdxruby
 github:
   repo: https://github.com/pdxruby/pdxruby.github.io

--- a/job-guidelines.md
+++ b/job-guidelines.md
@@ -1,5 +1,6 @@
 ---
 title: Job Posting Guidelines
+redirect_from: /job_guidelines
 ---
 
 Job Posting Guidelines


### PR DESCRIPTION
Extensionless permalinks are needed to ensure indexes
and redirects don't add a ".html" extension.

Redirect /job_guidelines → /job-guidelines for
consistency and to ensure redirects work correctly.