### PR TITLE
Better Calagator search link ("Attend our meetings") on index page.

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ projects and enthusiasm for Ruby – join us!
 
 There are many ways to participate in **pdxruby**:
 
--   [Attend our meetings](http://calagator.org/events/search?tag=pdxruby):
+-   [Attend our meetings](http://calagator.org/events/search?query=pdxruby):
     we have a number of regular meetings that everyone is welcome to
     attend:
     -   **General meetings** for formal presentations, lightning talks


### PR DESCRIPTION
Not all events have tags, so a general search for "pdxruby" will pick up more events.