### PR TITLE
fix 404 issue links

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "404: Page not found"
 permalink: 404.html
 ---
@@ -12,7 +11,7 @@ permalink: 404.html
         <a id="prose-create-link" href="http://prose.io/#{{ site.github.name }}/{{ site.github.project }}/tree/{{ site.github.branch }}/">Create this page</a> using Prose or <a id="github-create-link" href="https://github.com/{{ site.github.name }}/{{ site.github.project }}/new/{{ site.github.branch }}/">using Github</a>. Your edits will be submitted as a pull request which pirate volunteers will review and merge.
       </li>
       <li>
-        <a href="">Open an issue</a> to let us know the link is broken.
+        <a href="https://github.com/{{ site.github.name }}/{{ site.github.project }}/issues/new">Open an issue</a> to let us know the link is broken.
       </li>
       <li>
         <a href="{{ site.baseurl }}">Head back home</a> to try finding it again.


### PR DESCRIPTION
the 404 link doesn't go anywhere.

this change uses site.github.name and site.github.project to generate
the link