### PR TITLE
Add video links for April 2018

### DIFF
--- a/past-meetings.md
+++ b/past-meetings.md
@@ -6,6 +6,15 @@ title: Past Meetings
 
 ### 2018
 
+- April 2018 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HtHXWHtKvuCw6pjUvIa2CCk), or one-by-one:
+    - Megan Bigelow - [How perl changed my life](https://youtu.be/nhHaH3pugWI)
+    - Panel Discussion - [#talkpay](https://youtu.be/n3sEY_QSjEU)
+      - Robert Peterson (CitrusByte)
+      - Davy Stevenson (Fastly)
+      - Tim Loudon (Loudon & Company)
+      - Lauren Voswinkel (New Relic)
+      - Brent Miller (New Relic)
+
 - February 2018 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hs6mHfz-C5fwVnWvlKm2JE2), or one-by-one:
     - Rico Jones - [Rico <3 .xls](https://www.youtube.com/watch?v=mmqDvlldrMk)
     - Moof Mayeda - [Beautiful Data](https://www.youtube.com/watch?v=VZUr5-SSXLA)

--- a/past-meetings.md
+++ b/past-meetings.md
@@ -6,7 +6,7 @@ title: Past Meetings
 
 ### 2018
 
--   February 2018 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hs6mHfz-C5fwVnWvlKm2JE2), or one-by-one:
+- February 2018 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hs6mHfz-C5fwVnWvlKm2JE2), or one-by-one:
     - Rico Jones - [Rico <3 .xls](https://www.youtube.com/watch?v=mmqDvlldrMk)
     - Moof Mayeda - [Beautiful Data](https://www.youtube.com/watch?v=VZUr5-SSXLA)
     - Janik Knittle - [Escape From MechE](https://www.youtube.com/watch?v=jSFHVVVgRbI)
@@ -15,133 +15,133 @@ title: Past Meetings
 
 ### 2017
 
--   November 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hu8Lm-oYoAjHy1p0Nae8H5r), or one-by-one:
+- November 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hu8Lm-oYoAjHy1p0Nae8H5r), or one-by-one:
     - Randy Shoup: [When to Move to Microservices](https://www.youtube.com/watch?v=VkZLiMOK3mM)
     - Dana Scheider: [Executive Dysfunction And You](https://www.youtube.com/watch?v=MMhGBGABb5g)
 
--   September 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Huf-wqetkDM8p0MRTaLFj6t), or one-by-one:
+- September 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Huf-wqetkDM8p0MRTaLFj6t), or one-by-one:
     - Bryan Goss: [Testing from the Outside In: Why and How to Test Code](https://www.youtube.com/watch?v=PDBMcERj6e4)
 
--   August 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HtXdSQUaB7ncHYvEuzNf5Ej), or one-by-one:
-    -   Coraline Ada Ehmke: [Metaphors are Similes. Similes Are Like Metaphors](https://www.youtube.com/watch?v=SpXGVyI0IJg)
--   May 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hv42dx6-N-v63imUVgVpZbD), or one-by-one:
-    -   Dana Scheider: [A Beginner's Guide To Open Source](https://www.youtube.com/watch?v=Y56-rVG1PDg)
--   April 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hu1f_8RiuU7sofDQj_cwTH9), or one-by-one:
-    -   Tim Wade: [What We Talk About When We Talk About Unit Testing](https://www.youtube.com/watch?v=Pb8THg0-lo8)
--   March 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HtxUhJDNQxPE6LtdCpve0cg), or one-by-one:
-    -   Jason Clark: [Marshal, Marshal, Marshal](https://www.youtube.com/watch?v=KztXnR7HlYk)
-    -   Maureen Dugan: [Mob Programming](https://www.youtube.com/watch?v=JgGLpBo8IdE)
-    -   Kenichi Nakamura: [HTTP/2](https://www.youtube.com/watch?v=STNs8w7D6go)
+- August 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HtXdSQUaB7ncHYvEuzNf5Ej), or one-by-one:
+    - Coraline Ada Ehmke: [Metaphors are Similes. Similes Are Like Metaphors](https://www.youtube.com/watch?v=SpXGVyI0IJg)
+- May 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hv42dx6-N-v63imUVgVpZbD), or one-by-one:
+    - Dana Scheider: [A Beginner's Guide To Open Source](https://www.youtube.com/watch?v=Y56-rVG1PDg)
+- April 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Hu1f_8RiuU7sofDQj_cwTH9), or one-by-one:
+    - Tim Wade: [What We Talk About When We Talk About Unit Testing](https://www.youtube.com/watch?v=Pb8THg0-lo8)
+- March 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HtxUhJDNQxPE6LtdCpve0cg), or one-by-one:
+    - Jason Clark: [Marshal, Marshal, Marshal](https://www.youtube.com/watch?v=KztXnR7HlYk)
+    - Maureen Dugan: [Mob Programming](https://www.youtube.com/watch?v=JgGLpBo8IdE)
+    - Kenichi Nakamura: [HTTP/2](https://www.youtube.com/watch?v=STNs8w7D6go)
 
--   January 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HsUIEznF3ZITQUTpCXBlQiw), or one-by-one:
-    -   Lance Ivy: [Trust Issues: Application Security with JSON Web Tokens](https://www.youtube.com/watch?v=hPxIIVa19oA)
+- January 2017 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HsUIEznF3ZITQUTpCXBlQiw), or one-by-one:
+    - Lance Ivy: [Trust Issues: Application Security with JSON Web Tokens](https://www.youtube.com/watch?v=hPxIIVa19oA)
 
 ### 2016
 
--   November 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Htq_rfKUCHfXInaoY-Ati4F), or one-by-one:
-    -   Coraline Clark & Jason Clark: [Programming in the Small: Kids, Chickens, and Ruby](https://www.youtube.com/watch?v=61hg3n-72XQ)
+- November 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Htq_rfKUCHfXInaoY-Ati4F), or one-by-one:
+    - Coraline Clark & Jason Clark: [Programming in the Small: Kids, Chickens, and Ruby](https://www.youtube.com/watch?v=61hg3n-72XQ)
 
--   October 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HuiAWXa5lY_V5aDZa6qr4X6), or one-by-one:
-    -   Ryan Wise: [Breadth-first and A\* Search with the Ruby Standard Library](https://www.youtube.com/watch?v=Zp4SFxVsfNA)
+- October 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HuiAWXa5lY_V5aDZa6qr4X6), or one-by-one:
+    - Ryan Wise: [Breadth-first and A\* Search with the Ruby Standard Library](https://www.youtube.com/watch?v=Zp4SFxVsfNA)
 
--   September 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HuAhF4T0y3ZeHPQztSsRR3n), or one-by-one:
-    -   Brent Miller, Sam Livingston-Gray & Jesse Cooke: [Senior Rubyist Panel](https://www.youtube.com/watch?v=8CHt43o5Yr0)
-    -   Chuck Lauer Vose: [Concurrency in 5 minutes](https://www.youtube.com/watch?v=D5EoLrMVn28)
-    -   Jesse Cooke: [pdxruby contributions](https://www.youtube.com/watch?v=noD1wZ8nM2o)
-    -   Brian Shirai: [Rubinius](https://www.youtube.com/watch?v=5JihHI0wWgg)
+- September 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HuAhF4T0y3ZeHPQztSsRR3n), or one-by-one:
+    - Brent Miller, Sam Livingston-Gray & Jesse Cooke: [Senior Rubyist Panel](https://www.youtube.com/watch?v=8CHt43o5Yr0)
+    - Chuck Lauer Vose: [Concurrency in 5 minutes](https://www.youtube.com/watch?v=D5EoLrMVn28)
+    - Jesse Cooke: [pdxruby contributions](https://www.youtube.com/watch?v=noD1wZ8nM2o)
+    - Brian Shirai: [Rubinius](https://www.youtube.com/watch?v=5JihHI0wWgg)
 
--   August 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Htu80wP8K5xIUAj4DWIm_fv), or one-by-one:
-    -   Lauren Voswinkel: [Nitty Gritty Service Building](https://www.youtube.com/watch?v=hNcTeRW7wBY)
-    -   Josh Tompkins: [Redux-Style One-Way Data Flow (In Ruby)](https://www.youtube.com/watch?v=RxXeVIi9aQ8)
+- August 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2Htu80wP8K5xIUAj4DWIm_fv), or one-by-one:
+    - Lauren Voswinkel: [Nitty Gritty Service Building](https://www.youtube.com/watch?v=hNcTeRW7wBY)
+    - Josh Tompkins: [Redux-Style One-Way Data Flow (In Ruby)](https://www.youtube.com/watch?v=RxXeVIi9aQ8)
 
--   July 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HvnrLCSGE9Hp3TltIJhixoB), or one-by-one:
-    -   Dana Scheider: [Going Rambo: Contract and Collaboration Testing in Ruby](https://www.youtube.com/watch?v=unVJnnjOYzk)
-    -   Eric Drechsel: [Contributing to the new pdx.rb website](https://www.youtube.com/watch?v=nx7CJah_0ng)
+- July 2016 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HvnrLCSGE9Hp3TltIJhixoB), or one-by-one:
+    - Dana Scheider: [Going Rambo: Contract and Collaboration Testing in Ruby](https://www.youtube.com/watch?v=unVJnnjOYzk)
+    - Eric Drechsel: [Contributing to the new pdx.rb website](https://www.youtube.com/watch?v=nx7CJah_0ng)
 
 ### 2015
 
--   September 2015 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga), or one-by-one:
-    -   Jason Clark: [Testing the Multiverse](https://www.youtube.com/watch?v=AcVA6FWzZno&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=1)
-    -   Emily Bookstein: [So You Want Diversity in Tech?](https://www.youtube.com/watch?v=D7KDBBrVFfA&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=2)
-    -   Brian Shirai: [A Bit About Rubinius](https://www.youtube.com/watch?v=rLdBhXG-amM&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=3)
-    -   Jesse Cooke: [An Update on PDX.rb, Money, and Meetup.com](https://www.youtube.com/watch?v=UxOaGLV_u84&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=4)
-    -   Steve Bussert: [JavaScript This](https://www.youtube.com/watch?v=i5o7z8Z0hX0&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=5)
-    -   Jason Clark: [Livecoding with Shoes](https://www.youtube.com/watch?v=uIKvUDeUIj0&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=6)
--   August 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=xzDnXt0lc4Y&list=PLw_tewW7y2HsIr0Jsvm4TJvf_kbJ04aBO), or one-by-one:
-    -   \_why the lucky stiff: [Might I Recommend Ruby!](https://www.youtube.com/watch?v=wMk9skMEKG4)
-    -   Godfrey Chan: [Dropping Down to The Metal™](https://www.youtube.com/watch?v=xzDnXt0lc4Y)
-    -   Aaron Patterson: [Welcome to My Live Webinar](https://www.youtube.com/watch?v=0D62xzntahM)
--   July 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=wy-IGwNJagk&list=PLw_tewW7y2HvAINwsuBmK4nIkPHi82h5d&index=1), or one-by-one:
-    -   John Hyland: [Be Awesome By Being Boring](https://www.youtube.com/watch?v=wy-IGwNJagk)
-    -   Brent Miller: [Kung Fu](https://www.youtube.com/watch?v=iINEoZitysI)
-    -   Matt Scharr: [Encoding Stuff 'n' Things](https://www.youtube.com/watch?v=J0rEqgv58xI)
-    -   John Hyland: [Breaking Circuits for Great Justice](https://www.youtube.com/watch?v=K3Mz1MLPjmU)
-    -   Chris Dillon: [Encoding](https://www.youtube.com/watch?v=IG0oytnUIrg) plus [follow up blog post](http://squarism.com/2015/07/08/encoding-in-ruby-and-everywhere/)
-    -   Ryan Norman: [Stop Breaking Migrations](https://www.youtube.com/watch?v=hy9LOL42WTQ)
--   June 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=NtqOUvbrYNo&list=PLw_tewW7y2HtdtEj6eRHpPofFOiCzir5_), or one-by-one:
-    -   Chase Douglas: [Metasecurity: Beyond Patching Vulnerabilities](https://www.youtube.com/watch?v=NtqOUvbrYNo)
-    -   Evan Carmi: [Reverse Engineering: Finding the hidden API](https://www.youtube.com/watch?v=JkOGm_HFxR4)
-    -   Emily Hyland: [Programming for Humans](https://www.youtube.com/watch?v=CxoNWApyHkY)
-    -   Brent Miller: [Two True Fail Stories](https://www.youtube.com/watch?v=fg7qbAMOsfc)
-    -   Adam McFadden: [Game Programming in Ruby with Gosu](https://www.youtube.com/watch?v=uDU2W4eOEYg)
-    -   Victoria Wang: [A Lightning Talk About Neocities](https://www.youtube.com/watch?v=nksT6uJK4N0)
--   May 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=Cgg3ylFASYk&list=PLw_tewW7y2HsCkBwdYmDagJo4E5YL0MbD), or one-by-one:
-    -   Paul Jungwirth: [SQL in Rails](https://www.youtube.com/watch?v=Cgg3ylFASYk)
-    -   Justin Burris: [An American in Singapore](https://www.youtube.com/watch?v=gfnee5mQ7oI)
-    -   Jason Clark: [This Developer Typed \`bundle exec\`](https://www.youtube.com/watch?v=o_VHvwjFcmQ)
-    -   Jake Kaad: [Hacking Portland Startup Weekend](https://www.youtube.com/watch?v=oAk_-BzpnX0)
-    -   Audrey Eschright: [A Talk About Pay](https://www.youtube.com/watch?v=UkUB2paJk7M)
--   April 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=VS9g4wB6wZk&list=PLw_tewW7y2HudMVYTjtnel0nQi-AzZa3E), or one-by-one:
-    -   Mike Perham: [Using Background Jobs with Sidekiq and Rails](https://www.youtube.com/watch?v=VS9g4wB6wZk)
-    -   Katherine Wu: [Ask vs. Guess Culture](https://www.youtube.com/watch?v=_vMMb6VJlbQ)
-    -   Chuck Lauer Vose: [Rubygems – Gotta Catch Them All](https://www.youtube.com/watch?v=ph2g_8zt0lQ)
-    -   Jason Clark: [I \<3 StackProf](https://www.youtube.com/watch?v=vX8RIFwD7bE)
-    -   Matt Robinson: [A Devopsyish Story](https://www.youtube.com/watch?v=-PqJTmRO07w)
-    -   Chris Wright: [Statistical Regression to the Mean](https://www.youtube.com/watch?v=LdWfF_2GM6E)
-    -   Bracken Mosbacker: [Open Education](https://www.youtube.com/watch?v=VZqIRwvZeM0)
-    -   Zoe Kay: [Technical Book Clubs](https://www.youtube.com/watch?v=vNoomM-67uU)
--   January 2015 meeting videos:
-    -   Casey Rosenthal & Nathan Aschbacher: [Ruby & Elixir](https://www.youtube.com/watch?v=t64A4p3pp80)
-    -   Chris Dillon: [Arduino Cat Faucet](https://www.youtube.com/watch?v=tIdC7nS5kWI)
+- September 2015 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga), or one-by-one:
+    - Jason Clark: [Testing the Multiverse](https://www.youtube.com/watch?v=AcVA6FWzZno&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=1)
+    - Emily Bookstein: [So You Want Diversity in Tech?](https://www.youtube.com/watch?v=D7KDBBrVFfA&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=2)
+    - Brian Shirai: [A Bit About Rubinius](https://www.youtube.com/watch?v=rLdBhXG-amM&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=3)
+    - Jesse Cooke: [An Update on PDX.rb, Money, and Meetup.com](https://www.youtube.com/watch?v=UxOaGLV_u84&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=4)
+    - Steve Bussert: [JavaScript This](https://www.youtube.com/watch?v=i5o7z8Z0hX0&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=5)
+    - Jason Clark: [Livecoding with Shoes](https://www.youtube.com/watch?v=uIKvUDeUIj0&list=PLw_tewW7y2HuB0Dpq2y80FtqjnDNG3vga&index=6)
+- August 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=xzDnXt0lc4Y&list=PLw_tewW7y2HsIr0Jsvm4TJvf_kbJ04aBO), or one-by-one:
+    - \_why the lucky stiff: [Might I Recommend Ruby!](https://www.youtube.com/watch?v=wMk9skMEKG4)
+    - Godfrey Chan: [Dropping Down to The Metal™](https://www.youtube.com/watch?v=xzDnXt0lc4Y)
+    - Aaron Patterson: [Welcome to My Live Webinar](https://www.youtube.com/watch?v=0D62xzntahM)
+- July 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=wy-IGwNJagk&list=PLw_tewW7y2HvAINwsuBmK4nIkPHi82h5d&index=1), or one-by-one:
+    - John Hyland: [Be Awesome By Being Boring](https://www.youtube.com/watch?v=wy-IGwNJagk)
+    - Brent Miller: [Kung Fu](https://www.youtube.com/watch?v=iINEoZitysI)
+    - Matt Scharr: [Encoding Stuff 'n' Things](https://www.youtube.com/watch?v=J0rEqgv58xI)
+    - John Hyland: [Breaking Circuits for Great Justice](https://www.youtube.com/watch?v=K3Mz1MLPjmU)
+    - Chris Dillon: [Encoding](https://www.youtube.com/watch?v=IG0oytnUIrg) plus [follow up blog post](http://squarism.com/2015/07/08/encoding-in-ruby-and-everywhere/)
+    - Ryan Norman: [Stop Breaking Migrations](https://www.youtube.com/watch?v=hy9LOL42WTQ)
+- June 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=NtqOUvbrYNo&list=PLw_tewW7y2HtdtEj6eRHpPofFOiCzir5_), or one-by-one:
+    - Chase Douglas: [Metasecurity: Beyond Patching Vulnerabilities](https://www.youtube.com/watch?v=NtqOUvbrYNo)
+    - Evan Carmi: [Reverse Engineering: Finding the hidden API](https://www.youtube.com/watch?v=JkOGm_HFxR4)
+    - Emily Hyland: [Programming for Humans](https://www.youtube.com/watch?v=CxoNWApyHkY)
+    - Brent Miller: [Two True Fail Stories](https://www.youtube.com/watch?v=fg7qbAMOsfc)
+    - Adam McFadden: [Game Programming in Ruby with Gosu](https://www.youtube.com/watch?v=uDU2W4eOEYg)
+    - Victoria Wang: [A Lightning Talk About Neocities](https://www.youtube.com/watch?v=nksT6uJK4N0)
+- May 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=Cgg3ylFASYk&list=PLw_tewW7y2HsCkBwdYmDagJo4E5YL0MbD), or one-by-one:
+    - Paul Jungwirth: [SQL in Rails](https://www.youtube.com/watch?v=Cgg3ylFASYk)
+    - Justin Burris: [An American in Singapore](https://www.youtube.com/watch?v=gfnee5mQ7oI)
+    - Jason Clark: [This Developer Typed \`bundle exec\`](https://www.youtube.com/watch?v=o_VHvwjFcmQ)
+    - Jake Kaad: [Hacking Portland Startup Weekend](https://www.youtube.com/watch?v=oAk_-BzpnX0)
+    - Audrey Eschright: [A Talk About Pay](https://www.youtube.com/watch?v=UkUB2paJk7M)
+- April 2015 meeting videos [in playlist format](https://www.youtube.com/watch?v=VS9g4wB6wZk&list=PLw_tewW7y2HudMVYTjtnel0nQi-AzZa3E), or one-by-one:
+    - Mike Perham: [Using Background Jobs with Sidekiq and Rails](https://www.youtube.com/watch?v=VS9g4wB6wZk)
+    - Katherine Wu: [Ask vs. Guess Culture](https://www.youtube.com/watch?v=_vMMb6VJlbQ)
+    - Chuck Lauer Vose: [Rubygems – Gotta Catch Them All](https://www.youtube.com/watch?v=ph2g_8zt0lQ)
+    - Jason Clark: [I \<3 StackProf](https://www.youtube.com/watch?v=vX8RIFwD7bE)
+    - Matt Robinson: [A Devopsyish Story](https://www.youtube.com/watch?v=-PqJTmRO07w)
+    - Chris Wright: [Statistical Regression to the Mean](https://www.youtube.com/watch?v=LdWfF_2GM6E)
+    - Bracken Mosbacker: [Open Education](https://www.youtube.com/watch?v=VZqIRwvZeM0)
+    - Zoe Kay: [Technical Book Clubs](https://www.youtube.com/watch?v=vNoomM-67uU)
+- January 2015 meeting videos:
+    - Casey Rosenthal & Nathan Aschbacher: [Ruby & Elixir](https://www.youtube.com/watch?v=t64A4p3pp80)
+    - Chris Dillon: [Arduino Cat Faucet](https://www.youtube.com/watch?v=tIdC7nS5kWI)
 
 ### 2014
 
--   December 2014 meeting videos [in playlist format](https://www.youtube.com/watch?v=xG1S9ZPCy2Q&list=PLw_tewW7y2Hu78Fm2oxkHxVkmID1cP21V), or one-by-one:
-    -   Mike Perham: [Tribute to Ezra Zygmuntowicz](https://www.youtube.com/watch?v=xG1S9ZPCy2Q)
-    -   Davy Stevenson: [Benchmarking Ruby](https://www.youtube.com/watch?v=uO2Ts4Tn2oo)
-    -   Jonan Scheffler: [Sauron: DIY Home Security with Ruby!](https://www.youtube.com/watch?v=Vtf-JimNSdo)
--   October 2014 meeting videos [in playlist format](https://www.youtube.com/watch?v=P_e3laX8x90&list=PLw_tewW7y2HuMO4diBosq96GcuOMqRnPY), or one-by-one:
-    -   Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=P_e3laX8x90)
-    -   William Hertling: [Formatting a book with Ruby, HTML+CSS, & PrinceXML](https://www.youtube.com/watch?v=Ii4AaZT3w_w)
--   September 2014 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HsiK8qoweu41InbLOFjl5nN), or one-by-one:
-    -   Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=cLYCHvDafVY)
-    -   Michael Kaiser-Nyman: [How to Build An Internship Program](https://www.youtube.com/watch?v=uEMdUIQSRag)
-    -   Jason Clark: [Spelunking in Ruby](https://www.youtube.com/watch?v=ST0WS8_i0gs)
-    -   Carter Rabasa: [Fun with WebRTC, Web Audio, Sinatra & Twilio](https://www.youtube.com/watch?v=eJVmZGrDH-8)
--   July 2014 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA), or one-by-one:
-    -   Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=xAgNjB3Ku5g&list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA&index=1)
-    -   Dale Hollocher: [A lightning talk about technical blog posts](https://www.youtube.com/watch?v=fTQXyJRqGI0&index=2&list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA)
-    -   Maureen Dugan: [Anna Kournikova was a great tennis player; Lessons in TDD and Pairing](https://www.youtube.com/watch?v=7Y8XmJj-Y2o&list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA&index=3)
-    -   Brent Miller: Style Guides: Where Designers and Engineers Meet (sorry, no video available)
--   June 2014 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX), or one-by-one:
-    -   Kirsten Comandich: [Intro & Announcements](https://www.youtube.com/watch?v=ebwGh8wm3Ys&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX&index=1)
-    -   Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=WXnimlgA-k4&index=2&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX)
-    -   Rico Jones: [Programmatically Testing Routes in a Rails App](https://www.youtube.com/watch?v=Z1L4luUxvuc&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX&index=3)
-    -   Michael Kaiser-Nyman: [How to use Active Record without Rails](https://www.youtube.com/watch?v=3AnCXbfft9c&index=4&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX)
-    -   Jason Clark: [Get Your Shoes (Back) On!](https://www.youtube.com/watch?v=XYIGIxrDHZQ&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX&index=5)
-    -   Jonan Scheffler: [The Lifecycle of a Web Request](https://www.youtube.com/watch?v=U-4md8lYosk&index=6&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX)
--   [February 2014 meeting notes](/notes-02-2014) Yehuda Katz - Rust
+- December 2014 meeting videos [in playlist format](https://www.youtube.com/watch?v=xG1S9ZPCy2Q&list=PLw_tewW7y2Hu78Fm2oxkHxVkmID1cP21V), or one-by-one:
+    - Mike Perham: [Tribute to Ezra Zygmuntowicz](https://www.youtube.com/watch?v=xG1S9ZPCy2Q)
+    - Davy Stevenson: [Benchmarking Ruby](https://www.youtube.com/watch?v=uO2Ts4Tn2oo)
+    - Jonan Scheffler: [Sauron: DIY Home Security with Ruby!](https://www.youtube.com/watch?v=Vtf-JimNSdo)
+- October 2014 meeting videos [in playlist format](https://www.youtube.com/watch?v=P_e3laX8x90&list=PLw_tewW7y2HuMO4diBosq96GcuOMqRnPY), or one-by-one:
+    - Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=P_e3laX8x90)
+    - William Hertling: [Formatting a book with Ruby, HTML+CSS, & PrinceXML](https://www.youtube.com/watch?v=Ii4AaZT3w_w)
+- September 2014 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HsiK8qoweu41InbLOFjl5nN), or one-by-one:
+    - Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=cLYCHvDafVY)
+    - Michael Kaiser-Nyman: [How to Build An Internship Program](https://www.youtube.com/watch?v=uEMdUIQSRag)
+    - Jason Clark: [Spelunking in Ruby](https://www.youtube.com/watch?v=ST0WS8_i0gs)
+    - Carter Rabasa: [Fun with WebRTC, Web Audio, Sinatra & Twilio](https://www.youtube.com/watch?v=eJVmZGrDH-8)
+- July 2014 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA), or one-by-one:
+    - Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=xAgNjB3Ku5g&list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA&index=1)
+    - Dale Hollocher: [A lightning talk about technical blog posts](https://www.youtube.com/watch?v=fTQXyJRqGI0&index=2&list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA)
+    - Maureen Dugan: [Anna Kournikova was a great tennis player; Lessons in TDD and Pairing](https://www.youtube.com/watch?v=7Y8XmJj-Y2o&list=PLw_tewW7y2HtP6H3hg_f8qwEhI3yVEnrA&index=3)
+    - Brent Miller: Style Guides: Where Designers and Engineers Meet (sorry, no video available)
+- June 2014 meeting videos [in playlist format](https://www.youtube.com/playlist?list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX), or one-by-one:
+    - Kirsten Comandich: [Intro & Announcements](https://www.youtube.com/watch?v=ebwGh8wm3Ys&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX&index=1)
+    - Markus Roberts: [Thinking Outside The Framework](https://www.youtube.com/watch?v=WXnimlgA-k4&index=2&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX)
+    - Rico Jones: [Programmatically Testing Routes in a Rails App](https://www.youtube.com/watch?v=Z1L4luUxvuc&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX&index=3)
+    - Michael Kaiser-Nyman: [How to use Active Record without Rails](https://www.youtube.com/watch?v=3AnCXbfft9c&index=4&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX)
+    - Jason Clark: [Get Your Shoes (Back) On!](https://www.youtube.com/watch?v=XYIGIxrDHZQ&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX&index=5)
+    - Jonan Scheffler: [The Lifecycle of a Web Request](https://www.youtube.com/watch?v=U-4md8lYosk&index=6&list=PLw_tewW7y2HthpjgMf_TluVpAZ0I0uKMX)
+- [February 2014 meeting notes](/notes-02-2014) Yehuda Katz - Rust
 
 ### 2013
 
--   May 2013 meeting videos:
-    -   Audrey Eschright leads discussion on [things we learned from Igal Koshevoy](http://www.youtube.com/watch?v=KBdJ_e2emZ4&feature=player_detailpage#t=535s)
-    -   Markus Roberts: [Ruby Hangman](http://www.youtube.com/watch?feature=player_detailpage&v=KBdJ_e2emZ4#t=2134s) \| [puzzle posted to list](https://groups.google.com/d/msg/pdxruby/U9YuEGSnMQ8/ykmfSr4I6tAJ)
-    -   Bill Den Beste: [Generating Business Documents with Prawn](http://www.youtube.com/watch?feature=player_detailpage&v=KBdJ_e2emZ4#t=3504s) \| [slides](https://groups.google.com/d/msg/pdxruby/Ie8QEZgi-os/LbopQOiK5ZoJ)
-    -   Reid Beels: [Generating Business Documents with PDFKit](http://www.youtube.com/watch?feature=player_detailpage&v=KBdJ_e2emZ4#t=5899s)
--   February 2013 Videos:
-    -   Markus Roberts: [Ruby Hangman](http://www.youtube.com/watch?v=wQT-wdkKrN4)
-    -   Lennon Day-Reynolds: [Ruby Engineering at Twitter](http://www.youtube.com/watch?v=TlnIfzmrQmw)
+- May 2013 meeting videos:
+    - Audrey Eschright leads discussion on [things we learned from Igal Koshevoy](http://www.youtube.com/watch?v=KBdJ_e2emZ4&feature=player_detailpage#t=535s)
+    - Markus Roberts: [Ruby Hangman](http://www.youtube.com/watch?feature=player_detailpage&v=KBdJ_e2emZ4#t=2134s) \| [puzzle posted to list](https://groups.google.com/d/msg/pdxruby/U9YuEGSnMQ8/ykmfSr4I6tAJ)
+    - Bill Den Beste: [Generating Business Documents with Prawn](http://www.youtube.com/watch?feature=player_detailpage&v=KBdJ_e2emZ4#t=3504s) \| [slides](https://groups.google.com/d/msg/pdxruby/Ie8QEZgi-os/LbopQOiK5ZoJ)
+    - Reid Beels: [Generating Business Documents with PDFKit](http://www.youtube.com/watch?feature=player_detailpage&v=KBdJ_e2emZ4#t=5899s)
+- February 2013 Videos:
+    - Markus Roberts: [Ruby Hangman](http://www.youtube.com/watch?v=wQT-wdkKrN4)
+    - Lennon Day-Reynolds: [Ruby Engineering at Twitter](http://www.youtube.com/watch?v=TlnIfzmrQmw)
 
 ### Older
 


### PR DESCRIPTION
This PR adds links for April 2018 videos and cleans up the whitespace in `past-meetings.md` (use one space after `-` vs three).