### PR TITLE
Add information for Coordinator-Role

### DIFF
--- a/coordinator-role.md
+++ b/coordinator-role.md
@@ -1,0 +1,24 @@
+---
+title: Coordinator Role
+---
+
+A volunteer is selected by the organization to serve as the meeting coordinator for a six month term.  
+
+This role requires 5-10 hours a month emailing people and setting up speakers.  At each meetup, the coordinator should ask the group if anyone is available to speak the following month.  There is a Slack channel dedicated to discussing 'meetup-speakers' and another dedicated to 'pdxruby-bizness' that the coordinator should join.  
+
+The coordinator should reach out to folks who they think would have an interesting story - sometimes friends or colleagues and sometimes just cold calling (everyone is usually nice even if they say no).
+
+Putting together a good talk generally takes 5-20 hours, depending on depth etc., so folks usually need to be notified a few weeks prior to speaking in order to prepare.
+
+### Agenda
+
+The agenda for the meetup and the speakers need to be confirmed the Friday before the event so that the Event Hosts can organize pizza and beverages.  
+
+
+#### If you need to cancel and event
+
+If a meeting needs to be cancelled.  
+
+ - Post in the Slack Announcements channel
+ - Post in the Twitter account
+ - Cancel the event through Meetup


### PR DESCRIPTION
Add information for the group coordinator to improve hand-offs and ensure that the new person has the necessary information and tools available to them.  