### PR TITLE
Fix edit via GitHub button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ github:
   repo: https://github.com/pdxruby/pdxruby.github.io
   name: pdxruby
   project: pdxruby.github.io
-  branch: master
+  branch: main
 # For the prose editor
 prose:
   relativeLinks: 'http://pdxruby.github.io/links.jsonp'


### PR DESCRIPTION
Updates `config.github.branch` to `main`

Relates to:
- https://github.com/pdxruby/pdxruby.github.io/commit/6a48dcc126d00efc5dcd636c2d8580b39177d422